### PR TITLE
Match single line comments with begin/end patterns

### DIFF
--- a/grammars/elm.cson
+++ b/grammars/elm.cson
@@ -215,7 +215,8 @@
         'captures':
           '1':
             'name': 'punctuation.definition.comment.elm'
-        'match': '(--).*$\\n?'
+        'begin': '--'
+        'end': '$'
         'name': 'comment.line.double-dash.elm'
       }
       {


### PR DESCRIPTION
This allows injection grammars (e.g. [language-todo](https://github.com/atom/language-todo)) to parse what is in between.

Note: you might want to double check the regex, see also https://github.com/zargony/atom-language-rust/pull/13

old:
![screenshot from 2014-12-14 16 03 22](https://cloud.githubusercontent.com/assets/2464627/5427744/cd5fd304-83aa-11e4-9d7c-ef6cc37a956a.png)

new:
![screenshot from 2014-12-14 16 01 03](https://cloud.githubusercontent.com/assets/2464627/5427737/7827994e-83aa-11e4-917f-063105eb6c66.png)
