### PR TITLE
Update comments.cson

### DIFF
--- a/grammars/comments.cson
+++ b/grammars/comments.cson
@@ -1,5 +1,5 @@
 'name': 'Comments'
-'scope': 'source.elm'
+'scopeName': 'source.elm'
 'settings':
   'shellVariables': [
     {


### PR DESCRIPTION
Minor fix: changed the 'scope' cson property to 'scopeName' to fix a warning message in the javascript console (toggle it with ctrl shift i):

> Failed to load grammar: /home/jo/.atom/packages/language-elm/grammars/comments.cson Error: Grammar missing required scopeName property: /home/jo/.atom/packages/language-elm/grammars/comments.cson
>   at /usr/local/share/atom/resources/app/node_modules/first-mate/lib/grammar-registry.js:131:64
>   at /usr/local/share/atom/resources/app/node_modules/season/lib/cson.js:244:61
>   at fs.js:295:14
>   at Object.oncomplete (fs.js:93:15)
