### PR TITLE
Set autoIndentOnPaste to false

### DIFF
--- a/settings/language-elm.cson
+++ b/settings/language-elm.cson
@@ -1,4 +1,5 @@
 '.source.elm':
   'editor':
+    'autoIndentOnPaste': false
     'commentStart': '-- '
     'increaseIndentPattern': '((^.*(=|[|!%$?~+:\\-.=</>&\\\\*^]+|\\bthen|\\belse|\\bof)\\s*$)|(^.*\\bif(?!.*\\bthen\\b.*\\belse\\b.*).*$))'


### PR DESCRIPTION
Auto-indenting on paste seemed to never work properly.
language-python also disables this setting; I'm guessing it only
works out-of-the-box for languages with brackets or otherwise
obvious blocks.