### PR TITLE
Fixes #10: Recursively find the closest elm project path

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,7 +1,9 @@
 'use babel';
 
 const { BufferedNodeProcess } = require('atom');
-const path = require('path');
+const {sep, join} = require('path');
+const { statSync } = require('fs');
+const pathCache = new Map();
 
 module.exports = {
   selector: '.source.elm',
@@ -10,14 +12,46 @@ module.exports = {
 
   getSuggestions({editor, bufferPosition, scopeDescriptor, prefix}) {
     return new Promise((resolve, reject) => {
-      const filePath = editor.getPath();
-      const fileFolder = path.join(...filePath.split(path.sep).slice(0, -1));
       const lines = [];
-      const executablePath = atom.config.get('language-elm.elmOraclePath');
-      const options = {
-        cwd: fileFolder,
-        env: process.env
-      };
+
+      // Finds and caches the elm project path closest to the given path
+      const findClosestElmProjectPath = function(pathParts) {
+        const path = pathParts.length ? join(...pathParts) : '';
+
+        if (pathCache.has(path)) {
+          return pathCache.get(path);
+        } else {
+          try {
+            const elmProjectPath = recursivelyFindClosestElmProjectPath(pathParts, path);
+            pathCache.set(path, elmProjectPath);
+            return elmProjectPath
+          } catch (error) {
+            displayAutoCompletionsUnavailableWarning();
+            throw error;
+          }
+        }
+
+        function recursivelyFindClosestElmProjectPath(pathParts, startPath) {
+          const path = startPath
+                     ? startPath
+                     : pathParts.length
+                     ? join(...pathParts)
+                     : '';
+
+          const exactDependenciesPath = path ? `${path}${sep}elm-stuff${sep}exact-dependencies.json` : '';
+
+          if (path) {
+            try {
+              const stats = statSync(exactDependenciesPath);
+              return path;
+            } catch(e) {
+              return recursivelyFindClosestElmProjectPath(pathParts.slice(0, -1));
+            }
+          } else {
+            throw new Error('No elm project directory found');
+          }
+        }
+      }
 
       const onProcessError = function({error, handle}) {
         if (atom.inDevMode()) {
@@ -26,7 +60,7 @@ module.exports = {
               + [executablePath, filePath, prefix].join(' ')
               + '\n\n'
               + 'From the following directory:'
-              + fileFolder
+              + elmProjectPath
               + '\n\n'
               + error.message
           });
@@ -48,13 +82,16 @@ module.exports = {
       };
 
       const noOutputFromOracleError = function() {
+        displayAutoCompletionsUnavailableWarning();
+        return new Error('No elm-oracle suggestions');
+      }
+
+      const displayAutoCompletionsUnavailableWarning = function() {
         atom.notifications.addWarning('Elm AutoCompletions Unavailable', {
           detail: 'Please ensure you have:\n'
             + '  - Set the proper elm-oracle path\n'
             + '  - run `elm package install` within your project folder'
         });
-
-        return new Error('No elm-oracle suggestions');
       }
 
       const toOracleSuggestions = function(text) {
@@ -84,6 +121,14 @@ module.exports = {
           toAutocompletePlusSuggestions(
             toOracleSuggestions(
               parseOutput(lines[0]))));
+      };
+
+      const filePath = editor.getPath();
+      const elmProjectPath = findClosestElmProjectPath(filePath.split(sep).slice(0, -1));
+      const executablePath = atom.config.get('language-elm.elmOraclePath');
+      const options = {
+        cwd: elmProjectPath,
+        env: process.env
       };
 
       (new BufferedNodeProcess({


### PR DESCRIPTION
Sorry everyone! I had a central misunderstanding: elm-oracle needs to be run from the correct project path, rather than the location of a given file. For some reason I wrongly thought elm-oracle would find the nearest elm project. Turns out that's not the case :)

Thanks to @ivanoats for coding up another solution! While I agree we could go with a single path from which to run elm-oracle (the root of the atom project), I thought it would be nice if this plugin could be a bit more flexible and support atom projects that contained several small projects within the same repo, ala the `elm-architecture-tutorial` repo.

Therefore, I wrote this little function that finds and caches the nearest elm-project directory. It should fix #10 in the process, and be a bit more flexible as well.