### PR TITLE
Fixes #17: Use absolute elm project path in place of relative path

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,9 +1,16 @@
 'use babel';
 
 const { BufferedNodeProcess } = require('atom');
-const {sep, join} = require('path');
 const { statSync } = require('fs');
+const { sep: pathSep,
+        join: joinPath,
+        resolve: resolvePath } = require('path');
+
+const LOG_PREFIX = 'Elm Autocomplete: ';
+const RELATIVE_EXACT_DEPS_PATH = joinPath('elm-stuff', 'exact-dependencies.json');
+
 const pathCache = new Map();
+let seenUnavailableWarning = false;
 
 module.exports = {
   selector: '.source.elm',
@@ -13,123 +20,30 @@ module.exports = {
   getSuggestions({editor, bufferPosition, scopeDescriptor, prefix}) {
     return new Promise((resolve, reject) => {
       const lines = [];
-
-      // Finds and caches the elm project path closest to the given path
-      const findClosestElmProjectPath = function(pathParts) {
-        const path = pathParts.length ? join(...pathParts) : '';
-
-        if (pathCache.has(path)) {
-          return pathCache.get(path);
-        } else {
-          try {
-            const elmProjectPath = recursivelyFindClosestElmProjectPath(pathParts, path);
-            pathCache.set(path, elmProjectPath);
-            return elmProjectPath
-          } catch (error) {
-            displayAutoCompletionsUnavailableWarning();
-            throw error;
-          }
-        }
-
-        function recursivelyFindClosestElmProjectPath(pathParts, startPath) {
-          const path = startPath
-                     ? startPath
-                     : pathParts.length
-                     ? join(...pathParts)
-                     : '';
-
-          const exactDependenciesPath = path ? `${path}${sep}elm-stuff${sep}exact-dependencies.json` : '';
-
-          if (path) {
-            try {
-              const stats = statSync(exactDependenciesPath);
-              return path;
-            } catch(e) {
-              return recursivelyFindClosestElmProjectPath(pathParts.slice(0, -1));
-            }
-          } else {
-            throw new Error('No elm project directory found');
-          }
-        }
-      }
-
-      const onProcessError = function({error, handle}) {
-        if (atom.inDevMode()) {
-          atom.notifications.addError('Elm Autocomplete Error', {
-            detail: 'Failed to run:'
-              + [executablePath, filePath, prefix].join(' ')
-              + '\n\n'
-              + 'From the following directory:'
-              + elmProjectPath
-              + '\n\n'
-              + error.message
-          });
-        }
-
-        handle();
-
-        throw error;
+      const filePath = editor.getPath();
+      const elmProjectPath = findClosestElmProjectPath(filePath.split(pathSep).slice(0, -1));
+      const executablePath = atom.config.get('language-elm.elmOraclePath');
+      const options = {
+        cwd: elmProjectPath,
+        env: process.env
       };
 
-      const oracleSuggestionsParseError = function(error) {
-        if (atom.inDevMode()) {
-          atom.notifications.addError('Elm Autocomplete Error', {
-            detail: 'Failed to parse elm-oracle suggestions. Full error message: \n\n' + error.message
-          });
-        }
-
-        throw error;
-      };
-
-      const noOutputFromOracleError = function() {
-        displayAutoCompletionsUnavailableWarning();
-        return new Error('No elm-oracle suggestions');
-      }
-
-      const displayAutoCompletionsUnavailableWarning = function() {
-        atom.notifications.addWarning('Elm AutoCompletions Unavailable', {
-          detail: 'Please ensure you have:\n'
-            + '  - Set the proper elm-oracle path\n'
-            + '  - run `elm package install` within your project folder'
-        });
-      }
-
-      const toOracleSuggestions = function(text) {
-        try {
-          return JSON.parse(text);
-        } catch (error) {
-           throw oracleSuggestionsParseError(error);
-        }
-      };
-
-      const parseOutput = function(text) {
-        text = text && text.slice(0, text.indexOf('\n'));
-
-        if (!text) {
-          throw noOutputFromOracleError();
-        } else {
-          return text;
-        }
-      }
-
-      const accumulateOutput = function(line) {
+      const accumulateOutput = (line) => {
         lines.push(line)
       };
 
-      const provideSuggestions = function() {
+      const provideSuggestions = () => {
         resolve(
           toAutocompletePlusSuggestions(
             toOracleSuggestions(
               parseOutput(lines[0]))));
       };
 
-      const filePath = editor.getPath();
-      const elmProjectPath = findClosestElmProjectPath(filePath.split(sep).slice(0, -1));
-      const executablePath = atom.config.get('language-elm.elmOraclePath');
-      const options = {
-        cwd: elmProjectPath,
-        env: process.env
-      };
+      if (atom.inDevMode()) {
+        console.log(`${LOG_PREFIX} Executing - ${executablePath} ${filePath} ${prefix}`);
+        console.log(`${LOG_PREFIX} From Directory - ${elmProjectPath}`);
+        console.log('');
+      }
 
       (new BufferedNodeProcess({
         command: executablePath,
@@ -142,7 +56,7 @@ module.exports = {
   }
 };
 
-const toAutocompletePlusSuggestions = function(oracleSuggestions) {
+const toAutocompletePlusSuggestions = (oracleSuggestions) => {
   return oracleSuggestions.map(({comment, fullName, href, name, signature}) => {
     return {
       type: 'function',
@@ -167,7 +81,7 @@ const toAutocompletePlusSuggestions = function(oracleSuggestions) {
  *   - List#partition
  *   - Color#radial
  */
-const parseTabStops = function(signature) {
+const parseTabStops = (signature) => {
   return signature.split(')')
     .filter((suggestion) => suggestion.trim().length)
     .reduce((acc, part) => {
@@ -186,3 +100,110 @@ const parseTabStops = function(signature) {
       return acc;
     }, { tabStops: [], position: 0 }).tabStops.join(' ');
 };
+
+const buildAbsolutePath = (pathParts) => resolvePath(pathSep, ...pathParts);
+
+const recursivelyFindClosestElmProjectPath = (pathParts, startPath) => {
+  const path = startPath
+             ? startPath
+             : pathParts.length
+             ? buildAbsolutePath(pathParts)
+             : '';
+  let exactDependenciesPath;
+
+  if (path) {
+    exactDependenciesPath = joinPath(path, RELATIVE_EXACT_DEPS_PATH);
+
+    try {
+      const stats = statSync(exactDependenciesPath);
+      return path;
+    } catch(e) {
+      return recursivelyFindClosestElmProjectPath(pathParts.slice(0, -1));
+    }
+  } else {
+    throw new Error('No elm project directory found');
+  }
+}
+
+// Finds and caches the elm project path closest to the given path
+const findClosestElmProjectPath = (pathParts) => {
+  const path = pathParts.length ? buildAbsolutePath(pathParts) : '';
+
+  if (pathCache.has(path)) {
+    return pathCache.get(path);
+  } else {
+    try {
+      const elmProjectPath = recursivelyFindClosestElmProjectPath(pathParts, path);
+      pathCache.set(path, elmProjectPath);
+      return elmProjectPath
+    } catch (error) {
+      displayAutoCompletionsUnavailableWarning();
+      throw error;
+    }
+  }
+}
+
+const onProcessError = ({error, handle}) => {
+  if (atom.inDevMode()) {
+    atom.notifications.addError('Elm Autocomplete Error', {
+      detail: 'Failed to run:'
+        + [executablePath, filePath, prefix].join(' ')
+        + '\n\n'
+        + 'From the following directory:'
+        + elmProjectPath
+        + '\n\n'
+        + error.message
+    });
+  }
+
+  handle();
+
+  throw error;
+};
+
+const oracleSuggestionsParseError = (error) => {
+  if (atom.inDevMode()) {
+    atom.notifications.addError('Elm Autocomplete Error', {
+      detail: 'Failed to parse elm-oracle suggestions. Full error message: \n\n' + error.message
+    });
+  }
+
+  throw error;
+};
+
+const noOutputFromOracleError = () => {
+  displayAutoCompletionsUnavailableWarning();
+  return new Error('No elm-oracle suggestions');
+}
+
+const displayAutoCompletionsUnavailableWarning = () => {
+  if (seenUnavailableWarning) {
+    return;
+  }
+
+  atom.notifications.addWarning('Elm AutoCompletions Unavailable', {
+    detail: 'Please ensure you have:\n'
+      + '  - Set the proper elm-oracle path\n'
+      + '  - run `elm package install` within your project folder'
+  });
+
+  seenUnavailableWarning = true;
+}
+
+const toOracleSuggestions = (text) => {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+     throw oracleSuggestionsParseError(error);
+  }
+};
+
+const parseOutput = (text) => {
+  text = text && text.slice(0, text.indexOf('\n'));
+
+  if (!text) {
+    throw noOutputFromOracleError();
+  } else {
+    return text;
+  }
+}


### PR DESCRIPTION
The elm-project path was previously found using relative paths. Unfortunately, this is one of those cases where it worked on my Mac, but not on linux environments. Sorry everyone!

I'm now using absolute paths which should work cross-platform. I've also performed code style updates to prevent creating so many unnecessary functions.
