### PR TITLE
Fixes #13: Improve the prefix being passed to elm-oracle

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -12,14 +12,26 @@ const RELATIVE_EXACT_DEPS_PATH = joinPath('elm-stuff', 'exact-dependencies.json'
 const pathCache = new Map();
 let seenUnavailableWarning = false;
 
+const getPrefix = (editor, bufferPosition) => {
+  // Whatever your prefix regex might be
+  const regex = /[.\w0-9_-]+$/;
+
+  // Get the text for the line up to the triggered buffer position
+  const line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition]);
+
+  // Match the regex to the line, and return the match
+  return line.match(regex) ? line.match(regex)[0] : '';
+}
+
 module.exports = {
   selector: '.source.elm',
   inclusionPriority: 1,
   excludeLowerPriority: false,
 
-  getSuggestions({editor, bufferPosition, scopeDescriptor, prefix}) {
+  getSuggestions({editor, bufferPosition, scopeDescriptor}) {
     return new Promise((resolve, reject) => {
       const lines = [];
+      const prefix = getPrefix(editor, bufferPosition);
       const filePath = editor.getPath();
       const elmProjectPath = findClosestElmProjectPath(filePath.split(pathSep).slice(0, -1));
       const executablePath = atom.config.get('language-elm.elmOraclePath');


### PR DESCRIPTION
In order to get module-specific completions from elm-oracle, we need to change up the string, known as a prefix, that's passed to elm-oracle.

Before this change, the following string in your editor: `Signal.m` would be passed to elm-oracle with only the `m`, preventing module-specific completions from working.

Now, the plugin will send `Signal.m` to elm-oracle, and we'll get those very nice, context-aware suggestions :)