### PR TITLE
Autocomplete Bugfix / Refactor

### DIFF
--- a/lib/elmOracle.js
+++ b/lib/elmOracle.js
@@ -10,84 +10,78 @@ const PATH_CACHE = new Map()
 const LOG_PREFIX = 'Elm Autocomplete: '
 
 module.exports = (prefix, filePath) => {
-  return (shouldProvideSuggestions) => {
-    if (!shouldProvideSuggestions) {
-      return []
+  return new Promise(resolve => {
+    const lines = []
+    const elmProjectPath = findClosestElmProjectPath(filePath.split(path.sep).slice(0, -1))
+    const executablePath = atom.config.get('language-elm.elmOraclePath')
+    const options = {
+      cwd: elmProjectPath,
+      env: process.env
     }
 
-    return new Promise(resolve => {
-      const lines = []
-      const elmProjectPath = findClosestElmProjectPath(filePath.split(path.sep).slice(0, -1))
-      const executablePath = atom.config.get('language-elm.elmOraclePath')
-      const options = {
-        cwd: elmProjectPath,
-        env: process.env
-      }
+    const accumulateOutput = (line) => {
+      lines.push(line)
+    }
 
-      const accumulateOutput = (line) => {
-        lines.push(line)
-      }
+    const provideSuggestions = () => {
+      resolve(JSON.parse((parseOutput(lines[0]))))
+    }
 
-      const provideSuggestions = () => {
-        resolve(JSON.parse((parseOutput(lines[0]))))
-      }
+    if (atom.inDevMode()) {
+      console.log(`${LOG_PREFIX} Executing - ${executablePath} ${filePath} ${prefix}`)
+      console.log(`${LOG_PREFIX} From Directory - ${elmProjectPath}`)
+    }
 
+    const onProcessError = ({error, handle}) => {
       if (atom.inDevMode()) {
-        console.log(`${LOG_PREFIX} Executing - ${executablePath} ${filePath} ${prefix}`)
-        console.log(`${LOG_PREFIX} From Directory - ${elmProjectPath}`)
+        atom.notifications.addError('Elm Autocomplete Error', {
+          detail: 'Failed to run:' +
+            [executablePath, filePath, prefix].join(' ') +
+            '\n\n' +
+            'From the following directory:' +
+            elmProjectPath +
+            '\n\n' +
+            error.message
+        })
       }
 
-      const onProcessError = ({error, handle}) => {
-        if (atom.inDevMode()) {
-          atom.notifications.addError('Elm Autocomplete Error', {
-            detail: 'Failed to run:' +
-              [executablePath, filePath, prefix].join(' ') +
-              '\n\n' +
-              'From the following directory:' +
-              elmProjectPath +
-              '\n\n' +
-              error.message
-          })
-        }
+      handle()
 
-        handle()
+      throw error
+    }
 
-        throw error
-      }
+    // Fix for windows as BufferedNodeProcess doesn't spawn properly; See Atom issue 2887.
+    if (process.platform === 'win32') {
+      var results = spawn(getCmdPath(), ['/c', executablePath, filePath, prefix], options)
 
-      // Fix for windows as BufferedNodeProcess doesn't spawn properly; See Atom issue 2887.
-      if (process.platform === 'win32') {
-        var results = spawn(getCmdPath(), ['/c', executablePath, filePath, prefix], options)
+      results.stdout.on('data', function (data) {
+        accumulateOutput(data.toString())
+      })
 
-        results.stdout.on('data', function (data) {
-          accumulateOutput(data.toString())
-        })
+      results.on('close', function () {
+        provideSuggestions()
+      })
 
-        results.on('close', function () {
-          provideSuggestions()
-        })
-
-        results.on('error', function (err) {
-          throw err
-        })
-      } else {
-        (new BufferedNodeProcess({
-          command: executablePath,
-          args: [filePath, prefix],
-          options: options,
-          stdout: accumulateOutput,
-          exit: provideSuggestions
-        })).onWillThrowError(onProcessError)
-      }
-    })
-  }
+      results.on('error', function (err) {
+        throw err
+      })
+    } else {
+      (new BufferedNodeProcess({
+        command: executablePath,
+        args: [filePath, prefix],
+        options: options,
+        stdout: accumulateOutput,
+        exit: provideSuggestions
+      })).onWillThrowError(onProcessError)
+    }
+  })
 }
 
 const recursivelyFindClosestElmProjectPath = (pathParts, startPath) => {
   const projectPath = startPath ||
-    pathParts.length
-      ? buildAbsolutePath(pathParts)
-      : ''
+  pathParts.length
+    ? buildAbsolutePath(pathParts)
+    : ''
 
   let exactDependenciesPath
 

--- a/lib/elmOracle.js
+++ b/lib/elmOracle.js
@@ -16,89 +16,88 @@ module.exports = (prefix, filePath) => {
     }
 
     return new Promise(resolve => {
-        const lines = []
-        const elmProjectPath = findClosestElmProjectPath(filePath.split(path.sep).slice(0, -1))
-        const executablePath = atom.config.get('language-elm.elmOraclePath')
-        const options = {
-          cwd: elmProjectPath,
-          env: process.env
-        }
+      const lines = []
+      const elmProjectPath = findClosestElmProjectPath(filePath.split(path.sep).slice(0, -1))
+      const executablePath = atom.config.get('language-elm.elmOraclePath')
+      const options = {
+        cwd: elmProjectPath,
+        env: process.env
+      }
 
-        const accumulateOutput = (line) => {
-          lines.push(line)
-        }
+      const accumulateOutput = (line) => {
+        lines.push(line)
+      }
 
-        const provideSuggestions = () => {
-          resolve(JSON.parse((parseOutput(lines[0]))))
-        }
+      const provideSuggestions = () => {
+        resolve(JSON.parse((parseOutput(lines[0]))))
+      }
 
+      if (atom.inDevMode()) {
+        console.log(`${LOG_PREFIX} Executing - ${executablePath} ${filePath} ${prefix}`)
+        console.log(`${LOG_PREFIX} From Directory - ${elmProjectPath}`)
+      }
+
+      const onProcessError = ({error, handle}) => {
         if (atom.inDevMode()) {
-          console.log(`${LOG_PREFIX} Executing - ${executablePath} ${filePath} ${prefix}`)
-          console.log(`${LOG_PREFIX} From Directory - ${elmProjectPath}`)
+          atom.notifications.addError('Elm Autocomplete Error', {
+            detail: 'Failed to run:' +
+              [executablePath, filePath, prefix].join(' ') +
+              '\n\n' +
+              'From the following directory:' +
+              elmProjectPath +
+              '\n\n' +
+              error.message
+          })
         }
 
-        const onProcessError = ({error, handle}) => {
-          if (atom.inDevMode()) {
-            atom.notifications.addError('Elm Autocomplete Error', {
-              detail: 'Failed to run:'
-              + [executablePath, filePath, prefix].join(' ')
-              + '\n\n'
-              + 'From the following directory:'
-              + elmProjectPath
-              + '\n\n'
-              + error.message
-            })
-          }
+        handle()
 
-          handle()
+        throw error
+      }
 
-          throw error
-        }
+      // Fix for windows as BufferedNodeProcess doesn't spawn properly; See Atom issue 2887.
+      if (process.platform === 'win32') {
+        var results = spawn(getCmdPath(), ['/c', executablePath, filePath, prefix], options)
 
-        // Fix for windows as BufferedNodeProcess doesn't spawn properly; See Atom issue 2887.
-        if (process.platform === 'win32') {
-          var results = spawn(getCmdPath(), ['/c', executablePath, filePath, prefix], options)
+        results.stdout.on('data', function (data) {
+          accumulateOutput(data.toString())
+        })
 
-          results.stdout.on('data', function(data) {
-            accumulateOutput(data.toString())
-          })
+        results.on('close', function () {
+          provideSuggestions()
+        })
 
-          results.on('close', function() {
-            provideSuggestions()
-          })
-
-          results.on('error', function(err) {
-            throw err
-          })
-        } else {
-          (new BufferedNodeProcess({
-            command: executablePath,
-            args: [filePath, prefix],
-            options: options,
-            stdout: accumulateOutput,
-            exit: provideSuggestions
-          })).onWillThrowError(onProcessError)
-        }
-      })
+        results.on('error', function (err) {
+          throw err
+        })
+      } else {
+        (new BufferedNodeProcess({
+          command: executablePath,
+          args: [filePath, prefix],
+          options: options,
+          stdout: accumulateOutput,
+          exit: provideSuggestions
+        })).onWillThrowError(onProcessError)
+      }
+    })
   }
 }
 
 const recursivelyFindClosestElmProjectPath = (pathParts, startPath) => {
-  const projectPath =
-    startPath
-      ? startPath
-      : pathParts.length
-        ? buildAbsolutePath(pathParts)
-        : ''
+  const projectPath = startPath ||
+    pathParts.length
+      ? buildAbsolutePath(pathParts)
+      : ''
+
   let exactDependenciesPath
 
   if (projectPath) {
     exactDependenciesPath = path.join(projectPath, RELATIVE_EXACT_DEPS_PATH)
 
     try {
-      const stats = statSync(exactDependenciesPath)
+      statSync(exactDependenciesPath)
       return projectPath
-    } catch(e) {
+    } catch (e) {
       return recursivelyFindClosestElmProjectPath(pathParts.slice(0, -1))
     }
   } else {
@@ -132,5 +131,15 @@ const parseOutput = (text) => {
     throw new Error('No elm-oracle suggestions')
   } else {
     return text
+  }
+}
+
+const getCmdPath = () => {
+  if (process.env.comspec) {
+    return process.env.comspec
+  } else if (process.env.SystemRoot) {
+    return path.join(process.env.SystemRoot, 'System32', 'cmd.exe')
+  } else {
+    return 'cmd.exe'
   }
 }

--- a/lib/elmOracle.js
+++ b/lib/elmOracle.js
@@ -1,0 +1,136 @@
+'use babel'
+
+const { BufferedNodeProcess } = require('atom')
+const { spawn } = require('child_process')
+const { statSync } = require('fs')
+const path = require('path')
+
+const RELATIVE_EXACT_DEPS_PATH = path.join('elm-stuff', 'exact-dependencies.json')
+const PATH_CACHE = new Map()
+const LOG_PREFIX = 'Elm Autocomplete: '
+
+module.exports = (prefix, filePath) => {
+  return (shouldProvideSuggestions) => {
+    if (!shouldProvideSuggestions) {
+      return []
+    }
+
+    return new Promise(resolve => {
+        const lines = []
+        const elmProjectPath = findClosestElmProjectPath(filePath.split(path.sep).slice(0, -1))
+        const executablePath = atom.config.get('language-elm.elmOraclePath')
+        const options = {
+          cwd: elmProjectPath,
+          env: process.env
+        }
+
+        const accumulateOutput = (line) => {
+          lines.push(line)
+        }
+
+        const provideSuggestions = () => {
+          resolve(JSON.parse((parseOutput(lines[0]))))
+        }
+
+        if (atom.inDevMode()) {
+          console.log(`${LOG_PREFIX} Executing - ${executablePath} ${filePath} ${prefix}`)
+          console.log(`${LOG_PREFIX} From Directory - ${elmProjectPath}`)
+        }
+
+        const onProcessError = ({error, handle}) => {
+          if (atom.inDevMode()) {
+            atom.notifications.addError('Elm Autocomplete Error', {
+              detail: 'Failed to run:'
+              + [executablePath, filePath, prefix].join(' ')
+              + '\n\n'
+              + 'From the following directory:'
+              + elmProjectPath
+              + '\n\n'
+              + error.message
+            })
+          }
+
+          handle()
+
+          throw error
+        }
+
+        // Fix for windows as BufferedNodeProcess doesn't spawn properly; See Atom issue 2887.
+        if (process.platform === 'win32') {
+          var results = spawn(getCmdPath(), ['/c', executablePath, filePath, prefix], options)
+
+          results.stdout.on('data', function(data) {
+            accumulateOutput(data.toString())
+          })
+
+          results.on('close', function() {
+            provideSuggestions()
+          })
+
+          results.on('error', function(err) {
+            throw err
+          })
+        } else {
+          (new BufferedNodeProcess({
+            command: executablePath,
+            args: [filePath, prefix],
+            options: options,
+            stdout: accumulateOutput,
+            exit: provideSuggestions
+          })).onWillThrowError(onProcessError)
+        }
+      })
+  }
+}
+
+const recursivelyFindClosestElmProjectPath = (pathParts, startPath) => {
+  const projectPath =
+    startPath
+      ? startPath
+      : pathParts.length
+        ? buildAbsolutePath(pathParts)
+        : ''
+  let exactDependenciesPath
+
+  if (projectPath) {
+    exactDependenciesPath = path.join(projectPath, RELATIVE_EXACT_DEPS_PATH)
+
+    try {
+      const stats = statSync(exactDependenciesPath)
+      return projectPath
+    } catch(e) {
+      return recursivelyFindClosestElmProjectPath(pathParts.slice(0, -1))
+    }
+  } else {
+    throw new Error('No elm project directory found')
+  }
+}
+
+const buildAbsolutePath = (pathParts) => path.resolve(path.sep, ...pathParts)
+
+// Finds and caches the elm project path closest to the given path
+const findClosestElmProjectPath = (pathParts) => {
+  const path = pathParts.length ? buildAbsolutePath(pathParts) : ''
+
+  if (PATH_CACHE.has(path)) {
+    return PATH_CACHE.get(path)
+  } else {
+    try {
+      const elmProjectPath = recursivelyFindClosestElmProjectPath(pathParts, path)
+      PATH_CACHE.set(path, elmProjectPath)
+      return elmProjectPath
+    } catch (error) {
+      throw error
+    }
+  }
+}
+
+const parseOutput = (text) => {
+  text = text && text.slice(0, text.indexOf('\n'))
+
+  if (!text) {
+    throw new Error('No elm-oracle suggestions')
+  } else {
+    return text
+  }
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,7 @@
-'use babel';
+'use babel'
 
-const provider = require('./provider');
-const { join } = require('path');
+const provider = require('./provider')
+const { join } = require('path')
 
 module.exports = {
   config: {
@@ -22,7 +22,7 @@ module.exports = {
     }
   },
 
-  provide() {
-    return [provider];
+  provide () {
+    return [provider]
   }
 }

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,39 +1,7 @@
-'use babel';
+'use babel'
 
-const { BufferedNodeProcess,
-        File } = require('atom');
-const { spawn } = require('child_process');
-const { statSync } = require('fs');
-const { sep: pathSep,
-        join: joinPath,
-        resolve: resolvePath } = require('path');
-
-const LOG_PREFIX = 'Elm Autocomplete: ';
-const RELATIVE_EXACT_DEPS_PATH = joinPath('elm-stuff', 'exact-dependencies.json');
-
-const pathCache = new Map();
-let seenUnavailableWarning = false;
-
-const getPrefix = (editor, bufferPosition) => {
-  const regex = /[.\w0-9_-]+$/;
-  const line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition]);
-
-  return line.match(regex) ? line.match(regex)[0] : '';
-}
-
-const shouldPreventAutocomplete = (prefix, filePath) => {
-  const shouldPrevent = prefix.length < atom.config.get('language-elm.minCharsForAutocomplete')
-    || !atom.config.get('language-elm.autocompleteEnabled')
-    || !filePath;
-
-  if (shouldPrevent) {
-    return Promise.resolve(shouldPrevent);
-  } else {
-    return new File(filePath)
-      .exists()
-      .then(exists => !exists);
-  }
-}
+const { File } = require('atom')
+const getSuggestionsFromElmOracle = require('./elmOracle')
 
 module.exports = {
   selector: '.source.elm',
@@ -42,89 +10,38 @@ module.exports = {
   excludeLowerPriority: false,
 
   getSuggestions({editor, bufferPosition, scopeDescriptor}) {
-    const prefix = getPrefix(editor, bufferPosition);
-    const filePath = editor.getPath();
+    const prefix = getPrefix(editor, bufferPosition)
+    const filePath = editor.getPath()
 
-    return shouldPreventAutocomplete(prefix, filePath).then(prevent => {
-      if (prevent) {
-        return null;
-      }
+    return shouldProvideSuggestions(prefix, filePath)
+      .then(getSuggestionsFromElmOracle(prefix, filePath))
+      .then(mapToAutocompletePlusSuggestions)
+      .catch(onError)
+  }
+}
 
-      const lines = [];
-      const elmProjectPath = findClosestElmProjectPath(filePath.split(pathSep).slice(0, -1));
-      const executablePath = atom.config.get('language-elm.elmOraclePath');
-      const options = {
-        cwd: elmProjectPath,
-        env: process.env
-      };
+const getPrefix = (editor, bufferPosition) => {
+  const regex = /[.\w0-9_-]+$/
+  const line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
 
-      const accumulateOutput = (line) => {
-        lines.push(line)
-      };
+  return line.match(regex) ? line.match(regex)[0] : ''
+}
 
-      const provideSuggestions = () => {
-        return toAutocompletePlusSuggestions(
-          toOracleSuggestions(
-            parseOutput(lines[0])));
-      };
+const shouldProvideSuggestions = (prefix, filePath) => {
+  const shouldNotProvideSuggestions =
+    prefix.length < atom.config.get('language-elm.minCharsForAutocomplete')
+    || !atom.config.get('language-elm.autocompleteEnabled')
+    || !filePath
 
-      if (atom.inDevMode()) {
-        console.log(`${LOG_PREFIX} Executing - ${executablePath} ${filePath} ${prefix}`);
-        console.log(`${LOG_PREFIX} From Directory - ${elmProjectPath}`);
-        console.log('');
-      }
+  if (shouldNotProvideSuggestions) {
+    return Promise.resolve(false)
+  } else {
+    return new File(filePath).exists()
+  }
+}
 
-      const onProcessError = ({error, handle}) => {
-        if (atom.inDevMode()) {
-          atom.notifications.addError('Elm Autocomplete Error', {
-            detail: 'Failed to run:'
-            + [executablePath, filePath, prefix].join(' ')
-            + '\n\n'
-            + 'From the following directory:'
-            + elmProjectPath
-            + '\n\n'
-            + error.message
-          });
-        }
-
-        handle();
-
-        throw error;
-      };
-
-      // Fix for windows as BufferedNodeProcess doesn't spawn properly; See Atom issue 2887.
-      if (process.platform === 'win32') {
-        var results = spawn(getCmdPath(), ['/c', executablePath, filePath, prefix], options);
-
-        results.stdout.on('data', function(data) {
-          accumulateOutput(data.toString());
-        });
-
-        results.on('close', function() {
-          provideSuggestions();
-        });
-
-        results.on('error', function(err) {
-          displayAutoCompletionsUnavailableWarning();
-
-          if (atom.inDevMode()) {
-            throw err;
-          }
-        });
-      } else {
-        (new BufferedNodeProcess({
-          command: executablePath,
-          args: [filePath, prefix],
-          options: options,
-          stdout: accumulateOutput,
-          exit: provideSuggestions
-        })).onWillThrowError(onProcessError);
-      }
-      });
-    }
-  };
-
-const toAutocompletePlusSuggestions = (oracleSuggestions) => {
+// -- Autocomplete Plus Formatting
+const mapToAutocompletePlusSuggestions = (oracleSuggestions) => {
   return oracleSuggestions.map(({comment, fullName, href, name, signature}) => {
     return {
       type: 'function',
@@ -133,9 +50,9 @@ const toAutocompletePlusSuggestions = (oracleSuggestions) => {
       rightLabel: signature,
       description: fullName + (comment ? ': ' + comment : ''),
       descriptionMoreURL: href
-    };
-  });
-};
+    }
+  })
+}
 
 /**
  * TODO: This function works for some cases, but needs a rework with unit tests.
@@ -154,116 +71,42 @@ const parseTabStops = (signature) => {
     .filter((suggestion) => suggestion.trim().length)
     .reduce((acc, part) => {
       if ((/\(/g).test(part)) {
-        acc.tabStops.push('${' + ++acc.position + ':(' + part.replace(/\(|^(\ ?->)\ /g, '') + ')}');
+        acc.tabStops.push('${' + ++acc.position + ':(' + part.replace(/\(|^(\ ?->)\ /g, '') + ')}')
       } else {
         part
           .split('->')
           .filter((part) => part.trim().length)
           .slice(0, -1)
           .forEach((part) => {
-            acc.tabStops.push('${' + ++acc.position + ':' + part.trim() + '}');
-          });
+            acc.tabStops.push('${' + ++acc.position + ':' + part.trim() + '}')
+          })
       }
 
-      return acc;
-    }, { tabStops: [], position: 0 }).tabStops.join(' ');
-};
-
-const getCmdPath = () => {
-  if (process.env.comspec) {
-    return process.env.comspec
-  } else if (process.env.SystemRoot) {
-    return path.join(process.env.SystemRoot, 'System32', 'cmd.exe')
-  } else {
-    return 'cmd.exe'
-  }
+      return acc
+    }, { tabStops: [], position: 0 }).tabStops.join(' ')
 }
 
-const buildAbsolutePath = (pathParts) => resolvePath(pathSep, ...pathParts);
 
-const recursivelyFindClosestElmProjectPath = (pathParts, startPath) => {
-  const path = startPath
-             ? startPath
-             : pathParts.length
-             ? buildAbsolutePath(pathParts)
-             : '';
-  let exactDependenciesPath;
+// -- Error States
+const onError = (error) => {
+  displayAutoCompletionsUnavailableWarning()
 
-  if (path) {
-    exactDependenciesPath = joinPath(path, RELATIVE_EXACT_DEPS_PATH);
-
-    try {
-      const stats = statSync(exactDependenciesPath);
-      return path;
-    } catch(e) {
-      return recursivelyFindClosestElmProjectPath(pathParts.slice(0, -1));
-    }
-  } else {
-    throw new Error('No elm project directory found');
-  }
-}
-
-// Finds and caches the elm project path closest to the given path
-const findClosestElmProjectPath = (pathParts) => {
-  const path = pathParts.length ? buildAbsolutePath(pathParts) : '';
-
-  if (pathCache.has(path)) {
-    return pathCache.get(path);
-  } else {
-    try {
-      const elmProjectPath = recursivelyFindClosestElmProjectPath(pathParts, path);
-      pathCache.set(path, elmProjectPath);
-      return elmProjectPath
-    } catch (error) {
-      displayAutoCompletionsUnavailableWarning();
-      throw error;
-    }
-  }
-}
-
-const oracleSuggestionsParseError = (error) => {
   if (atom.inDevMode()) {
-    atom.notifications.addError('Elm Autocomplete Error', {
-      detail: 'Failed to parse elm-oracle suggestions. Full error message: \n\n' + error.message
-    });
+    console.error(error)
   }
-
-  throw error;
-};
-
-const noOutputFromOracleError = () => {
-  displayAutoCompletionsUnavailableWarning();
-  return new Error('No elm-oracle suggestions');
 }
 
+let seenUnavailableWarning = false
 const displayAutoCompletionsUnavailableWarning = () => {
   if (seenUnavailableWarning) {
-    return;
+    return
   }
 
   atom.notifications.addWarning('Elm AutoCompletions Unavailable', {
     detail: 'Please ensure you have:\n'
       + '  - Set the proper elm-oracle path\n'
       + '  - run `elm package install` within your project folder'
-  });
+  })
 
-  seenUnavailableWarning = true;
-}
-
-const toOracleSuggestions = (text) => {
-  try {
-    return JSON.parse(text);
-  } catch (error) {
-     throw oracleSuggestionsParseError(error);
-  }
-};
-
-const parseOutput = (text) => {
-  text = text && text.slice(0, text.indexOf('\n'));
-
-  if (!text) {
-    throw noOutputFromOracleError();
-  } else {
-    return text;
-  }
+  seenUnavailableWarning = true
 }

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -14,7 +14,7 @@ module.exports = {
     const filePath = editor.getPath()
 
     return shouldProvideSuggestions(prefix, filePath)
-      .then(getSuggestionsFromElmOracle(prefix, filePath))
+      .then(getElmOracleSuggestionsIfNecessary(prefix, filePath))
       .then(mapToAutocompletePlusSuggestions)
       .catch(onError)
   }
@@ -37,6 +37,16 @@ const shouldProvideSuggestions = (prefix, filePath) => {
     return Promise.resolve(false)
   } else {
     return new File(filePath).exists()
+  }
+}
+
+const getElmOracleSuggestionsIfNecessary = (prefix, filePath) => {
+  return (shouldProvideSuggestions) => {
+    if (shouldProvideSuggestions) {
+      return getSuggestionsFromElmOracle(prefix, filePath)
+    } else {
+      return []
+    }
   }
 }
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -9,7 +9,7 @@ module.exports = {
   inclusionPriority: 1,
   excludeLowerPriority: false,
 
-  getSuggestions({editor, bufferPosition, scopeDescriptor}) {
+  getSuggestions ({editor, bufferPosition, scopeDescriptor}) {
     const prefix = getPrefix(editor, bufferPosition)
     const filePath = editor.getPath()
 
@@ -29,9 +29,9 @@ const getPrefix = (editor, bufferPosition) => {
 
 const shouldProvideSuggestions = (prefix, filePath) => {
   const shouldNotProvideSuggestions =
-    prefix.length < atom.config.get('language-elm.minCharsForAutocomplete')
-    || !atom.config.get('language-elm.autocompleteEnabled')
-    || !filePath
+    prefix.length < atom.config.get('language-elm.minCharsForAutocomplete') ||
+      !atom.config.get('language-elm.autocompleteEnabled') ||
+      !filePath
 
   if (shouldNotProvideSuggestions) {
     return Promise.resolve(false)
@@ -86,7 +86,6 @@ const parseTabStops = (signature) => {
     }, { tabStops: [], position: 0 }).tabStops.join(' ')
 }
 
-
 // -- Error States
 const onError = (error) => {
   displayAutoCompletionsUnavailableWarning()
@@ -103,9 +102,9 @@ const displayAutoCompletionsUnavailableWarning = () => {
   }
 
   atom.notifications.addWarning('Elm AutoCompletions Unavailable', {
-    detail: 'Please ensure you have:\n'
-      + '  - Set the proper elm-oracle path\n'
-      + '  - run `elm package install` within your project folder'
+    detail: 'Please ensure you have:\n' +
+      '  - Set the proper elm-oracle path\n' +
+      '  - run `elm package install` within your project folder'
   })
 
   seenUnavailableWarning = true

--- a/package.json
+++ b/package.json
@@ -7,8 +7,15 @@
   "engines": {
     "atom": ">0.50.0"
   },
+  "scripts": {
+    "test": "./node_modules/.bin/standard"
+  },
   "dependencies": {
-    "elm-oracle": "^0.2.0"
+    "elm-oracle": "0.2.0"
+  },
+  "devDependencies": {
+    "standard": "5.4.1",
+    "pre-commit": "1.1.2"
   },
   "main": "./lib/main",
   "providedServices": {
@@ -17,5 +24,10 @@
         "2.0.0": "provide"
       }
     }
+  },
+  "standard": {
+    "globals": [
+      "atom"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "elm-oracle": "0.2.0"
   },
   "devDependencies": {
-    "standard": "5.4.1",
-    "pre-commit": "1.1.2"
+    "babel-eslint": "4.1.6",
+    "pre-commit": "1.1.2",
+    "standard": "5.4.1"
   },
   "main": "./lib/main",
   "providedServices": {
@@ -26,6 +27,7 @@
     }
   },
   "standard": {
+    "parser": "babel-eslint",
     "globals": [
       "atom"
     ]


### PR DESCRIPTION
Hey hey :) Creating PRs and merging to simply keep my thinking behind development documented in the repo.

After a recent bugfix, I realized we had broken the Autocomplete suggestions due to a subtle bug. But that made me question the codebase: The code I'd written started out as a 50-60 line experiment and grew into 250 after several bugfixes and hardening. This meant it needed a refactor to be more maintainable and easier to contribute to. I spent a couple hours this weekend doing just that!

Improvements:

  - Break most of the main logic out of the `getSuggestions` function into smaller functions and components to better Separate the view layer (atom autocomplete plus) from the data layer (elm oracle suggestions)
  - Create a separate module to fetch suggestions from Elm Oracle. Rather than accumulating output and then running all functions in a callback, treat the elm-oracle suggestions as a proper async task to enable smoother control flow and error handling. This means accumulating the output and resolving a promise with the output.
  - Added Standard JavaScript formatting to the project. This also includes a pre-commit hook that will fail the commit if any JS does not meet the formatting guidelines. This should make it easier for contributors to know the code style and follow along.