### PR TITLE
Amend grammar to accept Elm 0.17 module declaration

### DIFF
--- a/grammars/elm.cson
+++ b/grammars/elm.cson
@@ -36,7 +36,7 @@
       }
       {
         'match': '(exposing)'
-        'name': 'keyword.import.elm'
+        'name': 'keyword.other.elm'
       }
       {
         'include': '#module_exports'

--- a/grammars/elm.cson
+++ b/grammars/elm.cson
@@ -25,7 +25,7 @@
     'beginCaptures':
       '1':
         'name': 'keyword.other.elm'
-    'end': '\\b(where)\\b'
+    'end': '\\b(where)\\b|$|;'
     'endCaptures':
       '1':
         'name': 'keyword.other.elm'
@@ -33,6 +33,10 @@
     'patterns': [
       {
         'include': '#module_name'
+      }
+      {
+        'match': '(exposing)'
+        'name': 'keyword.import.elm'
       }
       {
         'include': '#module_exports'


### PR DESCRIPTION
Grammar now accepts both syntax variations:

Elm 0.16: `module Queue (..) where`
Elm 0.17: `module Queue exposing (..)`