### PR TITLE
Allow port and effect module declarations

### DIFF
--- a/grammars/elm.cson
+++ b/grammars/elm.cson
@@ -21,18 +21,29 @@
     'name': 'constant.language.empty-list.elm'
   }
   {
-    'begin': '^\\b(module)\\s+'
+    'begin': '^\\b((effect|port)\\s+)?(module)\\s+'
     'beginCaptures':
       '1':
         'name': 'keyword.other.elm'
-    'end': '\\b(where)\\b|$|;'
-    'endCaptures':
-      '1':
+      '3':
         'name': 'keyword.other.elm'
+    'end': '$|;'
     'name': 'meta.declaration.module.elm'
     'patterns': [
       {
         'include': '#module_name'
+      }
+      {
+        'begin': '(where)\\s*\\{'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.other.elm'
+        'end': '\\}'
+        'patterns': [
+          {
+            'include': '#type_signature'
+          }
+        ]
       }
       {
         'match': '(exposing)'
@@ -40,6 +51,10 @@
       }
       {
         'include': '#module_exports'
+      }
+      {
+        'match': '(where)'
+        'name': 'keyword.other.elm'
       }
       {
         'match': '[a-z]+'


### PR DESCRIPTION
Add support for `port` and `effect` module syntax.

Example of valid module declarations in 0.17:

```elm
effect module WebSocket where { command = MyCmd, subscription = MySub } exposing (
    send
  , listen
  , keepAlive
  )
```

```elm
port module Spelling exposing (..)
```

```elm
module WebSocket.LowLevel exposing ( WebSocket
  , open, Settings
  , send, close, closeWith
  , bytesQueued
  , BadOpen(..), BadClose(..), BadSend(..)
  )
```

```elm
module Main 
```

0.16:
```elm
module Config ( title ) where
```

(Please note, that at the time of this writing GitHub highlights the code blocks above according to 0.16 rules. This will change as soon as the [TextMate Rules](https://github.com/deadfoxygrandpa/Elm.tmLanguage/) are updated. I will PR there too.)