### PR TITLE
add lambda as operator

### DIFF
--- a/grammars/elm.cson
+++ b/grammars/elm.cson
@@ -227,7 +227,7 @@
     'include': '#infix_op'
   }
   {
-    'match': '[|!%$?~+:\\-.=</>&\\\\*^]+'
+    'match': '[|!%$?~+:\\-.=</>&\\\\λ*^]+'
     'name': 'keyword.operator.elm'
   }
   {


### PR DESCRIPTION
`λ` is an alias of `\` for starting a lambda function
