### PR TITLE
suggest with child_process.spawn on *nix platform

### DIFF
--- a/lib/elmOracle.js
+++ b/lib/elmOracle.js
@@ -24,7 +24,7 @@ module.exports = (prefix, filePath) => {
     }
 
     const provideSuggestions = () => {
-      resolve(JSON.parse((parseOutput(lines[0]))))
+      resolve(JSON.parse(parseOutput(lines.join(''))))
     }
 
     if (atom.inDevMode()) {
@@ -51,29 +51,22 @@ module.exports = (prefix, filePath) => {
     }
 
     // Fix for windows as BufferedNodeProcess doesn't spawn properly; See Atom issue 2887.
-    if (process.platform === 'win32') {
-      var results = spawn(getCmdPath(), ['/c', executablePath, filePath, prefix], options)
+    // if (process.platform === 'win32') {
+    var results = process.platform === 'win32'
+    ? spawn(getCmdPath(), ['/c', executablePath, filePath, prefix], options)
+    : spawn(executablePath, [filePath, prefix], options)
 
-      results.stdout.on('data', function (data) {
-        accumulateOutput(data.toString())
-      })
+    results.stdout.on('data', function (data) {
+      accumulateOutput(data.toString())
+    })
 
-      results.on('close', function () {
-        provideSuggestions()
-      })
+    results.on('close', function () {
+      provideSuggestions()
+    })
 
-      results.on('error', function (err) {
-        throw err
-      })
-    } else {
-      (new BufferedNodeProcess({
-        command: executablePath,
-        args: [filePath, prefix],
-        options: options,
-        stdout: accumulateOutput,
-        exit: provideSuggestions
-      })).onWillThrowError(onProcessError)
-    }
+    results.on('error', function (err) {
+      throw err
+    })
   })
 }
 


### PR DESCRIPTION
Fix #53.

This problem is caused by BufferedNodeProcess.

Also on *nix platform should child_process.spawn be used.